### PR TITLE
Proxy the RPC endpoint through SSL termination

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -252,6 +252,11 @@
 			"Rev": "b11a67434194733b34c11f206938263fa16ad1cf"
 		},
 		{
+			"ImportPath": "github.com/cssivision/reverseproxy",
+			"Comment": "v0.0.1-9-gb27a2af",
+			"Rev": "b27a2af48c77f8b28ea55a3be5ebc4d19704fce4"
+		},
+		{
 			"ImportPath": "github.com/dgrijalva/jwt-go",
 			"Comment": "v3.2.0-4-g3af4c74",
 			"Rev": "3af4c746e1c248ee8491a3e0c6f7a9cd831e95f8"

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
     <div class="container">
         <h1><a href="/">BlockForm</a></h1>
         <h2>Nodes</h2>
-        {{ if . }}
+        {{ if .Nodes }}
         <table class="table" id="nodes">
             <tr>
                 <th>Name</th>
@@ -17,7 +17,7 @@
                 <th>Provider</th>
                 <th>Endpoint</th>
             </tr>
-            {{range .}}
+            {{range .Nodes}}
             <tr>
                 <td class="align-middle">
                     <a href="/node?id={{.ID}}"><i class="fas fa-th-large"></i> <b>{{.Name}}</b></a>
@@ -40,7 +40,7 @@
                 <td>
                     {{if .DomainName}}
                         <div class="input-group mb-0 toclipboard" data-toggle="tooltip" data-placement="top" title="Copied!">
-                        <input class="form-control" type="text" value="http://{{.DomainName}}:8545/{{.APIKey}}" readonly>
+                        <input class="form-control" type="text" value="{{$.SiteURL}}/rpc/{{.ID}}/{{.APIKey}}" readonly>
                         <div class="input-group-append">
                             <button class="btn btn-outline-secondary" type="button"><i class="fas fa-copy"></i></button>
                         </div>

--- a/templates/node.html
+++ b/templates/node.html
@@ -4,6 +4,7 @@
     {{template "head" .}}
 </head>
 <body>
+    {{ with .Node }}
     <div class="container">
         <h1><a href="/">BlockForm</a></h1>
         <div class="smaller">
@@ -43,7 +44,7 @@
             <p>
                 <b>Web3 RPC endpoint:</b>
                 <div class="input-group mb-0 toclipboard" data-toggle="tooltip" data-placement="top" title="Copied!">
-                    <input class="form-control" type="text" value="http://{{.DomainName}}:8545/{{.APIKey}}" readonly>
+                    <input class="form-control" type="text" value="{{$.SiteURL}}/rpc/{{.ID}}/{{.APIKey}}" readonly>
                     <div class="input-group-append">
                         <button class="btn btn-outline-secondary" type="button"><i class="fas fa-copy"></i></button>
                     </div>
@@ -52,7 +53,7 @@
             <p>
                 <b>Geth attach:</b>
                 <div class="input-group mb-0 toclipboard" data-toggle="tooltip" data-placement="top" title="Copied!">
-                    <input class="form-control" type="text" value="geth attach http://{{.DomainName}}:8545/{{.APIKey}}" readonly>
+                    <input class="form-control" type="text" value="geth attach {{$.SiteURL}}/rpc/{{.ID}}/{{.APIKey}}" readonly>
                     <div class="input-group-append">
                         <button class="btn btn-outline-secondary" type="button"><i class="fas fa-copy"></i></button>
                     </div>
@@ -89,7 +90,7 @@
             </p>
             <script>
                 $( document ).ready(function() {
-                    var web3 = new Web3("http://{{.DomainName}}:8545/{{.APIKey}}");
+                    var web3 = new Web3("{{$.SiteURL}}/rpc/{{.ID}}/{{.APIKey}}");
                     web3.eth.isSyncing().then((data) => {
                         $('#syncing').html(data ? '<i class="fas fa-cloud-download-alt"></i> '+data.currentBlock+'/'+data.highestBlock : 'False');
                     });
@@ -101,5 +102,6 @@
             {{end}}
         </div>
     </div>
+    {{end}}
 </body>
 </html>

--- a/vendor/github.com/cssivision/reverseproxy/LICENSE
+++ b/vendor/github.com/cssivision/reverseproxy/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-present cssivision
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/cssivision/reverseproxy/README.md
+++ b/vendor/github.com/cssivision/reverseproxy/README.md
@@ -1,0 +1,68 @@
+# Introduction
+A minimalist proxy library for go, inspired by `net/http/httputil` and add support for HTTPS using HTTP Tunnel
+
+Support cancels an in-flight request by closing it's connection
+
+# Installation
+```sh
+go get github.com/cssivision/reverseproxy
+```
+
+# Usage
+
+## A simple proxy
+```go
+package main
+
+import (
+    "net/http"
+    "net/url"
+    "github.com/cssivision/reverseproxy"
+)
+
+func main() {
+    http.ListenAndServe(":8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        path, err := url.Parse("https://github.com")
+        if err != nil {
+            panic(err)
+            return
+        }
+        proxy := reverseproxy.NewReverseProxy(path)
+        proxy.ServeHTTP(w, r)
+    }))
+}
+```
+
+## Use as a proxy server
+
+To use proxy server, you should set browser to use the proxy server as an HTTP proxy.
+
+```go
+package main
+
+import (
+    "net/http"
+    "net/url"
+    "github.com/cssivision/reverseproxy"
+)
+
+func main() {
+    http.ListenAndServe(":8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        path, err := url.Parse("http://" + r.Host)
+        if err != nil {
+            panic(err)
+            return
+        }
+
+        proxy := reverseproxy.NewReverseProxy(path)
+        proxy.ServeHTTP(w, r)
+
+        // Specific for HTTP and HTTPS
+        // if r.Method == "CONNECT" {
+        //     proxy.ProxyHTTPS(w, r)
+        // } else {
+        //     proxy.ProxyHTTP(w, r)
+        // }
+    }))
+}
+```

--- a/vendor/github.com/cssivision/reverseproxy/reverse.go
+++ b/vendor/github.com/cssivision/reverseproxy/reverse.go
@@ -1,0 +1,376 @@
+package reverseproxy
+
+import (
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+var onExitFlushLoop func()
+
+const (
+	defaultTimeout = time.Minute * 5
+)
+
+// ReverseProxy is an HTTP Handler that takes an incoming request and
+// sends it to another server, proxying the response back to the
+// client, support http, also support https tunnel using http.hijacker
+type ReverseProxy struct {
+	// Set the timeout of the proxy server, default is 5 minutes
+	Timeout time.Duration
+
+	// Director must be a function which modifies
+	// the request into a new request to be sent
+	// using Transport. Its response is then copied
+	// back to the original client unmodified.
+	// Director must not access the provided Request
+	// after returning.
+	Director func(*http.Request)
+
+	// The transport used to perform proxy requests.
+	// default is http.DefaultTransport.
+	Transport http.RoundTripper
+
+	// FlushInterval specifies the flush interval
+	// to flush to the client while copying the
+	// response body. If zero, no periodic flushing is done.
+	FlushInterval time.Duration
+
+	// ErrorLog specifies an optional logger for errors
+	// that occur when attempting to proxy the request.
+	// If nil, logging goes to os.Stderr via the log package's
+	// standard logger.
+	ErrorLog *log.Logger
+
+	// ModifyResponse is an optional function that
+	// modifies the Response from the backend.
+	// If it returns an error, the proxy returns a StatusBadGateway error.
+	ModifyResponse func(*http.Response) error
+}
+
+type requestCanceler interface {
+	CancelRequest(req *http.Request)
+}
+
+// NewReverseProxy returns a new ReverseProxy that routes
+// URLs to the scheme, host, and base path provided in target. If the
+// target's path is "/base" and the incoming request was for "/dir",
+// the target request will be for /base/dir. if the target's query is a=10
+// and the incoming request's query is b=100, the target's request's query
+// will be a=10&b=100.
+// NewReverseProxy does not rewrite the Host header.
+// To rewrite Host headers, use ReverseProxy directly with a custom
+// Director policy.
+func NewReverseProxy(target *url.URL) *ReverseProxy {
+	targetQuery := target.RawQuery
+	director := func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
+
+		// If Host is empty, the Request.Write method uses
+		// the value of URL.Host.
+		// force use URL.Host
+		req.Host = req.URL.Host
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+
+		if _, ok := req.Header["User-Agent"]; !ok {
+			req.Header.Set("User-Agent", "")
+		}
+	}
+
+	return &ReverseProxy{Director: director}
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// Hop-by-hop headers. These are removed when sent to the backend.
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+var hopHeaders = []string{
+	"Connection",
+	"Proxy-Connection", // non-standard but still sent by libcurl and rejected by e.g. google
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",      // canonicalized version of "TE"
+	"Trailer", // not Trailers per URL above; http://www.rfc-editor.org/errata_search.php?eid=4522
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func (p *ReverseProxy) copyResponse(dst io.Writer, src io.Reader) {
+	if p.FlushInterval != 0 {
+		if wf, ok := dst.(writeFlusher); ok {
+			mlw := &maxLatencyWriter{
+				dst:     wf,
+				latency: p.FlushInterval,
+				done:    make(chan bool),
+			}
+
+			go mlw.flushLoop()
+			defer mlw.stop()
+			dst = mlw
+		}
+	}
+
+	io.Copy(dst, src)
+}
+
+type writeFlusher interface {
+	io.Writer
+	http.Flusher
+}
+
+type maxLatencyWriter struct {
+	dst     writeFlusher
+	latency time.Duration
+	mu      sync.Mutex
+	done    chan bool
+}
+
+func (m *maxLatencyWriter) Write(b []byte) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.dst.Write(b)
+}
+
+func (m *maxLatencyWriter) flushLoop() {
+	t := time.NewTicker(m.latency)
+	defer t.Stop()
+	for {
+		select {
+		case <-m.done:
+			if onExitFlushLoop != nil {
+				onExitFlushLoop()
+			}
+			return
+		case <-t.C:
+			m.mu.Lock()
+			m.dst.Flush()
+			m.mu.Unlock()
+		}
+	}
+}
+
+func (m *maxLatencyWriter) stop() {
+	m.done <- true
+}
+
+func (p *ReverseProxy) logf(format string, args ...interface{}) {
+	if p.ErrorLog != nil {
+		p.ErrorLog.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
+}
+
+func removeHeaders(header http.Header) {
+	// Remove hop-by-hop headers listed in the "Connection" header.
+	if c := header.Get("Connection"); c != "" {
+		for _, f := range strings.Split(c, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				header.Del(f)
+			}
+		}
+	}
+
+	// Remove hop-by-hop headers
+	for _, h := range hopHeaders {
+		if header.Get(h) != "" {
+			header.Del(h)
+		}
+	}
+}
+
+func addXForwardedForHeader(req *http.Request) {
+	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		// If we aren't the first proxy retain prior
+		// X-Forwarded-For information as a comma+space
+		// separated list and fold multiple headers into one.
+		if prior, ok := req.Header["X-Forwarded-For"]; ok {
+			clientIP = strings.Join(prior, ", ") + ", " + clientIP
+		}
+		req.Header.Set("X-Forwarded-For", clientIP)
+	}
+}
+
+func (p *ReverseProxy) ProxyHTTP(rw http.ResponseWriter, req *http.Request) {
+	transport := p.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	outreq := new(http.Request)
+	// Shallow copies of maps, like header
+	*outreq = *req
+
+	if cn, ok := rw.(http.CloseNotifier); ok {
+		if requestCanceler, ok := transport.(requestCanceler); ok {
+			// After the Handler has returned, there is no guarantee
+			// that the channel receives a value, so to make sure
+			reqDone := make(chan struct{})
+			defer close(reqDone)
+			clientGone := cn.CloseNotify()
+
+			go func() {
+				select {
+				case <-clientGone:
+					requestCanceler.CancelRequest(outreq)
+				case <-reqDone:
+				}
+			}()
+		}
+	}
+
+	p.Director(outreq)
+	outreq.Close = false
+
+	// We may modify the header (shallow copied above), so we only copy it.
+	outreq.Header = make(http.Header)
+	copyHeader(outreq.Header, req.Header)
+
+	// Remove hop-by-hop headers listed in the "Connection" header, Remove hop-by-hop headers.
+	removeHeaders(outreq.Header)
+
+	// Add X-Forwarded-For Header.
+	addXForwardedForHeader(outreq)
+
+	res, err := transport.RoundTrip(outreq)
+	if err != nil {
+		p.logf("http: proxy error: %v", err)
+		rw.WriteHeader(http.StatusBadGateway)
+		return
+	}
+
+	// Remove hop-by-hop headers listed in the "Connection" header of the response, Remove hop-by-hop headers.
+	removeHeaders(res.Header)
+
+	if p.ModifyResponse != nil {
+		if err := p.ModifyResponse(res); err != nil {
+			p.logf("http: proxy error: %v", err)
+			rw.WriteHeader(http.StatusBadGateway)
+			return
+		}
+	}
+
+	// Copy header from response to client.
+	copyHeader(rw.Header(), res.Header)
+
+	// The "Trailer" header isn't included in the Transport's response, Build it up from Trailer.
+	if len(res.Trailer) > 0 {
+		trailerKeys := make([]string, 0, len(res.Trailer))
+		for k := range res.Trailer {
+			trailerKeys = append(trailerKeys, k)
+		}
+		rw.Header().Add("Trailer", strings.Join(trailerKeys, ", "))
+	}
+
+	rw.WriteHeader(res.StatusCode)
+	if len(res.Trailer) > 0 {
+		// Force chunking if we saw a response trailer.
+		// This prevents net/http from calculating the length for short
+		// bodies and adding a Content-Length.
+		if fl, ok := rw.(http.Flusher); ok {
+			fl.Flush()
+		}
+	}
+
+	p.copyResponse(rw, res.Body)
+	// close now, instead of defer, to populate res.Trailer
+	res.Body.Close()
+	copyHeader(rw.Header(), res.Trailer)
+}
+
+func (p *ReverseProxy) ProxyHTTPS(rw http.ResponseWriter, req *http.Request) {
+	hij, ok := rw.(http.Hijacker)
+	if !ok {
+		p.logf("http server does not support hijacker")
+		return
+	}
+
+	clientConn, _, err := hij.Hijack()
+	if err != nil {
+		p.logf("http: proxy error: %v", err)
+		return
+	}
+
+	proxyConn, err := net.Dial("tcp", req.URL.Host)
+	if err != nil {
+		p.logf("http: proxy error: %v", err)
+		return
+	}
+
+	// The returned net.Conn may have read or write deadlines
+	// already set, depending on the configuration of the
+	// Server, to set or clear those deadlines as needed
+	// we set timeout to 5 minutes
+	deadline := time.Now()
+	if p.Timeout == 0 {
+		deadline = deadline.Add(time.Minute * 5)
+	} else {
+		deadline = deadline.Add(p.Timeout)
+	}
+
+	err = clientConn.SetDeadline(deadline)
+	if err != nil {
+		p.logf("http: proxy error: %v", err)
+		return
+	}
+
+	err = proxyConn.SetDeadline(deadline)
+	if err != nil {
+		p.logf("http: proxy error: %v", err)
+		return
+	}
+
+	_, err = clientConn.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
+	if err != nil {
+		p.logf("http: proxy error: %v", err)
+		return
+	}
+
+	go func() {
+		io.Copy(clientConn, proxyConn)
+		clientConn.Close()
+		proxyConn.Close()
+	}()
+
+	io.Copy(proxyConn, clientConn)
+	proxyConn.Close()
+	clientConn.Close()
+}
+
+func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.Method == "CONNECT" {
+		p.ProxyHTTPS(rw, req)
+	} else {
+		p.ProxyHTTP(rw, req)
+	}
+}


### PR DESCRIPTION
A quick and dirty way to get HTTPS RPC endpoints is to proxy them in the go app.

The host (in our case Heroku) frontend HTTP server takes care of encryption for us.

Won't scale.

Fixes #2

