### PR TITLE
auto rebuild/restart server

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,0 +1,13 @@
+[run]
+init_cmds = [["go", "build"], ["./blockform"]]
+watch_all = true
+watch_dirs = [
+	"$WORKDIR/"
+]
+watch_exts = [".go"]
+ignore = [".git"]
+
+# Minimal interval to Trigger build event
+build_delay = 2000
+
+cmds = [["go", "build"], ["./blockform"]]

--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ Get, build and run:
     go get github.com/WeTrustPlatform/blockform
     cd $GOPATH/src/github.com/WeTrustPlatform/blockform
     go build && ./blockform
+
+
+### Development
+- (Optional) Auto rebuild and restart server when you make changes in `*.go` files using [bra](https://github.com/Unknwon/bra)
+ * `go get github.com/Unknwon/bra`
+ * `bra run`
+ * Happy coding


### PR DESCRIPTION
This is optional for those don't want manually restart server while
writing code.  I haven't used it myself and would like to hear your
opnions.

I had a small script using fswatch https://github.com/WeTrustPlatform/charity-management-serv/blob/master/live_reload.sh
It works well on Mac but doesn't on my void-linux machine